### PR TITLE
Fix voidsuit oxygen tank check

### DIFF
--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -292,6 +292,7 @@ else if(##equipment_var) {\
 			return
 		if(tank)
 			to_chat(user, "\The [src] already has an airtank installed.")
+			return
 		if (istype(W, /obj/item/weapon/tank/scrubber))
 			to_chat(user, SPAN_WARNING("\The [W] is far too large to attach to \the [src]."))
 			return


### PR DESCRIPTION
Adds a missing return statement for the check that stops users from adding more than one O2 tank to a void suit.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->