### PR TITLE
Baystation char setup panel update rework.

### DIFF
--- a/code/modules/client/preference_setup/global/03_pai.dm
+++ b/code/modules/client/preference_setup/global/03_pai.dm
@@ -47,6 +47,7 @@
 /datum/category_item/player_setup_item/player_global/pai/OnTopic(var/href,var/list/href_list, var/mob/user)
 	if(href_list["option"])
 		var/t
+		. = TOPIC_REFRESH
 		switch(href_list["option"])
 			if("name")
 				t = sanitizeName(input(user, "Enter a name for your pAI", "Global Preference", candidate.name) as text|null, MAX_NAME_LEN, 1)
@@ -67,13 +68,15 @@
 			if("chassis")
 				candidate.chassis = input(user,"What would you like to use for your mobile chassis icon?") as null|anything in GLOB.possible_chassis
 				update_pai_preview(user)
+				. = TOPIC_HARD_REFRESH
 			if("say")
 				candidate.say_verb = input(user,"What theme would you like to use for your speech verbs?") as null|anything in GLOB.possible_say_verbs
 			if("cyclebg")
 				bgstate = next_in_list(bgstate, bgstate_options)
 				update_pai_preview(user)
+				. = TOPIC_HARD_REFRESH
 
-		return TOPIC_REFRESH
+		return
 
 	return ..()
 

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -373,7 +373,6 @@
 			return
 		var/value = text2num(href_list["newvalue"])
 		update_skill_value(J, S, value)
-		pref.open_setup_window(user)
 		panel.set_content(generate_skill_content(J))
 		panel.open()
 		return TOPIC_REFRESH

--- a/code/modules/client/preference_setup/occupation/skill_selection.dm
+++ b/code/modules/client/preference_setup/occupation/skill_selection.dm
@@ -211,7 +211,7 @@
 	return JOINTEXT(dat)
 
 /datum/category_item/player_setup_item/occupation/proc/open_skill_setup(mob/user, datum/job/job)
-	panel = new(user, "skill-selection","Skill Selection: [job.title]", "Skill Selection: [job.title]", 770, 850, src)
+	panel = new(user, "skill-selection", "Skill Selection: [job.title]", 770, 850, src)
 	panel.set_content(generate_skill_content(job))
 	panel.open()
 

--- a/code/modules/client/preference_setup/preference_setup.dm
+++ b/code/modules/client/preference_setup/preference_setup.dm
@@ -1,5 +1,6 @@
 #define TOPIC_UPDATE_PREVIEW 4
-#define TOPIC_REFRESH_UPDATE_PREVIEW (TOPIC_REFRESH|TOPIC_UPDATE_PREVIEW)
+#define TOPIC_HARD_REFRESH   8 // use to force a browse() call, unblocking some rsc operations
+#define TOPIC_REFRESH_UPDATE_PREVIEW (TOPIC_HARD_REFRESH|TOPIC_UPDATE_PREVIEW)
 
 var/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 
@@ -233,7 +234,9 @@ var/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 
 	if(. & TOPIC_UPDATE_PREVIEW)
 		pref_mob.client.prefs.preview_icon = null
-	if(. & TOPIC_REFRESH)
+	if(. & TOPIC_HARD_REFRESH)
+		pref_mob.client.prefs.open_setup_window(usr)
+	else if(. & TOPIC_REFRESH)
 		pref_mob.client.prefs.update_setup_window(usr)
 
 /datum/category_item/player_setup_item/CanUseTopic(var/mob/user)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -129,12 +129,7 @@ datum/preferences
 	if(!user || !user.client)
 		return
 
-	if(!get_mob_by_key(client_ckey))
-		to_chat(user, "<span class='danger'>No mob exists for the given client!</span>")
-		close_load_dialog(user)
-		return
-
-	var/dat = "<html><body><center>"
+	var/dat = "<center>"
 
 	if(is_guest)
 		dat += "Please create an account to save your preferences. If you have an account and are seeing this, please adminhelp for assistance."
@@ -151,27 +146,25 @@ datum/preferences
 	dat += player_setup.header()
 	dat += "<br><HR></center>"
 	dat += player_setup.content(user)
-	update_setup_window(user)
+	return dat
 
 /datum/preferences/proc/open_setup_window(mob/user)
-	var/datum/browser/popup = new(user, "preferences_browser", "Character Setup", 800, 800)
+	if(!SScharacter_setup.initialized)
+		return
+	var/datum/browser/popup = new(user, "preferences_browser", "Character Setup", 1200, 800, src)
 	var/content = {"
 	<script type='text/javascript'>
 		function update_content(data){
-			document.getElementById('content').innerHTML = data
+			document.getElementById('content').innerHTML = data;
 		}
 	</script>
-	<html><body>
-		<div id='content'>Loading...</div>
-	</body></html>
+	<div id='content'>[get_content(user)]</div>
 	"}
 	popup.set_content(content)
-	popup.open(FALSE) // Skip registring onclose on the browser pane
-	onclose(user, "preferences_window", src) // We want to register on the window itself
-	update_setup_window(user)
+	popup.open()
 
 /datum/preferences/proc/update_setup_window(mob/user)
-	send_output(user, get_content(user), "preferences_browser:update_content")
+	send_output(user, url_encode(get_content(user)), "preferences_browser.browser:update_content")
 
 /datum/preferences/proc/process_link(mob/user, list/href_list)
 


### PR DESCRIPTION
Bay has a different preview icon approach which is less compatible with this method (you can probably unblock the rsc asset via output call, send the new one, and refresh on receipt, but I am unwilling to implement that). Therefore any changes to the preview icons force a `browse()` call in this version. This does not affect interaction with the skill panel.

Please test on 512 before merging; I am unwilling to test 512 builds.